### PR TITLE
Rebuild tutorials automatically

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,50 @@
+name: Rebuild Tutorials
+on:
+  schedule:
+    - cron: 0 0 */3 * *
+  issue_comment:
+    types:
+      - created
+  push:
+env:
+  GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/19345468/trigger/pipeline
+  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+jobs:
+  Random rebuild:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl \
+            -X POST \
+            -F "token=$GITLAB_TOKEN" \
+            "$GITLAB_TRIGGER"
+  Manual rebuild:
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          arg="$(echo ${{ github.event.comment.body }} | cut -d' ' -f2)"
+          folder="$(echo $arg | cut -d/ -f1)"
+          file="$(echo $arg | cut -d/ -f2)"
+          curl \
+            -X POST \
+            -F "token=$GITLAB_CI_TOKEN" \
+            -F "variables[FOLDER]=$folder" \
+            -F "variables[FILE]=$file" \
+            "$GITLAB_TRIGGER"
+  Open PR:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rebuild/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Rebuild tutorials",
+              head: "${{ github.ref }}".split("/").slice(2).join("/"),
+              base: "master",
+            })

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -10,7 +10,7 @@ env:
   GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/19345468/trigger/pipeline
   GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
 jobs:
-  Random rebuild:
+  RandomRebuild:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,7 @@ jobs:
             -F "token=$GITLAB_TOKEN" \
             -F "ref=master" \
             "$GITLAB_TRIGGER"
-  Manual rebuild:
+  ManualRebuild:
     if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
     runs-on: ubuntu-latest
     steps:
@@ -30,12 +30,12 @@ jobs:
           file="$(echo $arg | cut -d/ -f2)"
           curl \
             -X POST \
-            -F "token=$GITLAB_CI_TOKEN" \
+            -F "token=$GITLAB_TOKEN" \
             -F "ref=master" \
             -F "variables[FOLDER]=$folder" \
             -F "variables[FILE]=$file" \
             "$GITLAB_TRIGGER"
-  Open PR:
+  OpenPR:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rebuild/')
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +47,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Rebuild tutorials",
-              head: "${{ github.ref }}".split("/").slice(2).join("/"),
+              head: "${{ github.ref }}".slice(11),
               base: "master",
             })

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -6,6 +6,7 @@ on:
     types:
       - created
   push:
+  status:
 env:
   GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/19345468/trigger/pipeline
   GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
@@ -44,9 +45,25 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              ...context.repo,
               title: "Rebuild tutorials",
               head: "${{ github.ref }}".slice(11),
               base: "master",
+            })
+  FixStatus:
+    if: github.event_name == 'status' && github.event.context == 'ci/gitlab/gitlab.com' && github.event.state == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: Replace this SHA with a tag when the next version is released.
+      - uses: actions/github-script@82b33c82ef5e155cb8e0de0862e5dbde0cd451eb
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.payload.sha,
+              state: "success",
+              context: context.payload.context,
+              description: "This status can be ignored",
+              target_url: context.payload.target_url,
             })

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -18,6 +18,7 @@ jobs:
           curl \
             -X POST \
             -F "token=$GITLAB_TOKEN" \
+            -F "ref=master" \
             "$GITLAB_TRIGGER"
   Manual rebuild:
     if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
@@ -30,6 +31,7 @@ jobs:
           curl \
             -X POST \
             -F "token=$GITLAB_CI_TOKEN" \
+            -F "ref=master" \
             -F "variables[FOLDER]=$folder" \
             -F "variables[FILE]=$file" \
             "$GITLAB_TRIGGER"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 Manifest.toml
 tutorials/**/*.html
 tutorials/**/*.pdf
+/*/*/jl_*/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,11 +6,10 @@ setup:
   stage: setup
   only:
     - triggers
+  image: python
   script: |
-    apt -qq update
-    DEBIAN_FRONTEND=noninteractive apt -qqy install python3-pip
-    pip3 install pyyaml
-    python3 make_pipeline.py > rebuild.yml
+    pip install pyyaml
+    python make_pipeline.py > rebuild.yml
   artifacts:
     paths:
       - rebuild.yml
@@ -21,3 +20,5 @@ rebuild:
     include:
       - artifact: rebuild.yml
         job: setup
+  variables:  # TODO: Delete after JuliaGPU/gitlab-ci#20
+    JULIA_PROJECT: "@."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,5 +18,6 @@ setup:
 rebuild:
   stage: rebuild
   trigger:
-    include: rebuild.yml
-    job: setup
+    include:
+      - artifact: rebuild.yml
+        job: setup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,5 +20,6 @@ rebuild:
     include:
       - artifact: rebuild.yml
         job: setup
+    strategy: depend
   variables:  # TODO: Delete after JuliaGPU/gitlab-ci#20
     JULIA_PROJECT: "@."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+stages:
+  - setup
+  - rebuild
+
+setup:
+  stage: setup
+  only:
+    - triggers
+  script: |
+    apt -qq update
+    DEBIAN_FRONTEND=noninteractive apt -qqy install python3-pip
+    pip3 install pyyaml
+    python3 make_pipeline.py > rebuild.yml
+  artifacts:
+    paths:
+      - rebuild.yml
+
+rebuild:
+  stage: rebuild
+  trigger:
+    include: rebuild.yml
+    job: setup

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -51,7 +51,7 @@ pipeline = {
     "rebuild": {
         "extends": ".julia:1.4",
         "variables": {
-            "CI_APT_INSTALL": "git texlive-science texlive-xetex",
+            "CI_APT_INSTALL": "git python3-dev texlive-science texlive-xetex",
             "JULIA_NUM_THREADS": 4,
         },
         "tags": tags,

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -49,7 +49,7 @@ pipeline = {
     "rebuild": {
         "extends": ".julia:1.4",
         "variables": {
-            "CI_APT_INSTALL": "texlive",
+            "CI_APT_INSTALL": "texlive-xetex",
             "JULIA_NUM_THREADS": 4,
         },
         "tags": [tag],

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -49,7 +49,7 @@ pipeline = {
     "rebuild": {
         "extends": ".julia:1.4",
         "variables": {
-            "CI_APT_INSTALL": "texlive-xetex",
+            "CI_APT_INSTALL": "texlive-xetex texlive-science",
             "JULIA_NUM_THREADS": 4,
         },
         "tags": [tag],

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -19,7 +19,7 @@ if not file:
     file = choice([f for f in os.listdir(folder) if f.endswith(".jmd") and f not in LONG])
 os.chdir(cwd)
 
-tag = "nvidia" if file in GPU else "intel"
+tags = ["nvidia"] if file in GPU else []
 
 script = f"""
 julia -e '
@@ -52,7 +52,7 @@ pipeline = {
             "CI_APT_INSTALL": "git texlive-science texlive-xetex",
             "JULIA_NUM_THREADS": 4,
         },
-        "tags": [tag],
+        "tags": tags,
         "script": script,
     },
 }

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -1,0 +1,60 @@
+import os
+
+from random import choice
+from sys import stdout
+from uuid import uuid4
+
+import yaml
+
+GPU = {"01-beeler-reuter.jmd"}
+LONG = {"02-workshop_solutions.jmd", "06-pendulum_bayesian_inference.jmd"}
+
+cwd = os.getcwd()
+os.chdir("tutorials")
+folder = os.getenv("FOLDER")
+if not folder:
+    folder = choice([d for d in os.listdir() if os.path.isdir(d)])
+file = os.getenv("FILE")
+if not file:
+    file = choice([f for f in os.listdir(folder) if f.endswith(".jmd") and f not in LONG])
+os.chdir(cwd)
+
+tag = "nvidia" if file in GPU else "intel"
+
+script = f"""
+julia -e '
+  using Pkg
+  Pkg.instantiate()
+  using DiffEqTutorials: weave_file
+  weave_file("{folder}", "{file}")'
+
+if [[ -z "$(git status -suno)" ]]; then
+  echo "No changes"
+  exit 0
+fi
+
+chmod 400 "$SSH_KEY"
+git config core.sshCommand "ssh -o StrictHostKeyChecking=no -i $SSH_KEY"
+git config user.name "github-actions[bot]"
+git config user.email "actions@github.com"
+branch="rebuild/{str(uuid4())[:8]}"
+git checkout -b "$branch"
+git commit -am "Rebuild tutorials"
+git remote add github "git@github.com:SciML/DiffEqTutorials.jl.git"
+git push github "$branch"
+"""
+
+pipeline = {
+    "include": "https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/templates/v6.yml",
+    "rebuild": {
+        "extends": ".julia:1.4",
+        "variables": {
+            "CI_APT_INSTALL": "texlive",
+            "JULIA_NUM_THREADS": 4,
+        },
+        "tags": [tag],
+        "script": script,
+    },
+}
+
+yaml.dump(pipeline, stdout)

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -33,6 +33,8 @@ if [[ -z "$(git status -suno)" ]]; then
   exit 0
 fi
 
+k="$(cat $SSH_KEY)"
+echo "$k" > "$SSH_KEY"
 chmod 400 "$SSH_KEY"
 git config core.sshCommand "ssh -o StrictHostKeyChecking=no -i $SSH_KEY"
 git config user.name "github-actions[bot]"

--- a/make_pipeline.py
+++ b/make_pipeline.py
@@ -49,7 +49,7 @@ pipeline = {
     "rebuild": {
         "extends": ".julia:1.4",
         "variables": {
-            "CI_APT_INSTALL": "texlive-xetex texlive-science",
+            "CI_APT_INSTALL": "git texlive-science texlive-xetex",
             "JULIA_NUM_THREADS": 4,
         },
         "tags": [tag],


### PR DESCRIPTION
First draft, I expect some things to be broken.

Here's what's *supposed* to happen:

- Every 3 days, GitHub Actions fires and triggers GitLab CI
- When GitLab CI is triggered, the `setup` job chooses a random folder and file, then emits a job config for that tutorial.
- The `rebuild` GitLab CI job reads this generated job config and executes it, by:
  - Building the tutorial
  - If there are changes, commit and push them to a new branch
- GitHub Actions receives notification of the new push, and opens a PR for that branch
- You can also manually trigger a rebuild of a specific tutorial by making an issue comment with the contents `!rebuild <folder>/<file>`, in which case the same process happens but without the random selection