### PR TITLE
Allow specifying rebuild branch

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          cmd="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2-)"
+          cmd="$(jq -r .comment.body < "$GITHUB_EVENT_PATH" | head -n1 | cut -d' ' -f2-)"
           while [[ "$cmd" != '' && "$cmd" != '!rebuild' ]]; do
             arg="$(echo $cmd | cut -d' ' -f1)"
             key="$(echo $arg | cut -d= -f1)"

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -7,34 +7,45 @@ on:
       - created
   push:
   status:
-env:
-  GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/19345468/trigger/pipeline
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
 jobs:
-  RandomRebuild:
-    if: github.event_name == 'schedule'
+  TriggerRebuild:
+    if: github.event_name == 'schedule' || github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
     runs-on: ubuntu-latest
     steps:
       - run: |
+          cmd="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2-)"
+          while [[ "$cmd" != '' && "$cmd" != '!rebuild' ]]; do
+            arg="$(echo $cmd | cut -d' ' -f1)"
+            key="$(echo $arg | cut -d= -f1)"
+            val="$(echo $arg | cut -d= -f2)"
+            case "$key" in
+              branch)
+                branch="$val"
+                ;;
+              file)
+                folder="$(echo $val | cut -d/ -f1)"
+                file="$(echo $val | cut -d/ -f2)"
+                ;;
+              *)
+                echo "Unknown command $key"
+                exit 1
+                ;;
+            esac
+            if echo "$cmd" | grep -q ' '; then
+              cmd="$(echo $cmd | cut -d' ' -f2)"
+            else
+              cmd=""
+            fi
+          done
           curl --fail \
-            -F "token=$GITLAB_TOKEN" \
+            -F "token=${{ secrets.GITLAB_TOKEN }}" \
             -F "ref=master" \
-            "$GITLAB_TRIGGER"
-  ManualRebuild:
-    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          arg="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2)"
-          folder="$(echo $arg | cut -d/ -f1)"
-          file="$(echo $arg | cut -d/ -f2)"
-          curl --fail \
-            -F "token=$GITLAB_TOKEN" \
-            -F "ref=master" \
+            -F "variables[BRANCH]=$branch" \
             -F "variables[FOLDER]=$folder" \
             -F "variables[FILE]=$file" \
-            "$GITLAB_TRIGGER"
-      - uses: actions/github-script@v2
+            https://gitlab.com/api/v4/projects/19345468/trigger/pipeline
+      - if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
This changes the syntax from `!rebuild folder/file` to `!rebuild file=folder/file` with an option `branch=name`.
So in a PR asking to merge changes to the tutorial `introduction/tutorial.jmd` from the branch `rebuild/abc123`, you would comment on the PR:

```
!rebuild file=introduction/tutorial.jmd branch=rebuild/abc123
```

And the PR would be updated in-place.

Also fixes a bit of fragility in the comment parsing when the comment contains a single quote, as well as adding the ability to just comment `!rebuild` to trigger a new random build.